### PR TITLE
Use proxy for both schemes: http and https

### DIFF
--- a/glato/gitlab/api.py
+++ b/glato/gitlab/api.py
@@ -63,8 +63,7 @@ class Api():
 
         self.proxies = None
         if proxy:
-            scheme = urlparse(proxy).scheme
-            self.proxies = {scheme: proxy}
+            self.proxies = {'http': proxy, 'https': proxy}
 
         # Initialize caches
         self._cache = {


### PR DESCRIPTION
Otherwise, in order to analyze https calls one needs to inform https proxy with valid certificates (or hack a little bit to inform a trust cert chain).

Closes #2

---

> First I create the issue because if you don't agree with this solution, can reject the PR but still track the issue to fix.

It's common to use http proxy for debugging purposes of https connections. Otherwise we need little hacks to made it works with requests lib, eg:

- https://stackoverflow.com/a/69222780
- https://www.th3r3p0.com/random/python-requests-and-burp-suite.html