### PR TITLE
enumerate-secrets can work with self-enumeration

### DIFF
--- a/glato/cli/cli.py
+++ b/glato/cli/cli.py
@@ -256,9 +256,10 @@ def _validate_args(args, token):
 
     # Check enumerate-secrets dependencies
     if args.enumerate_secrets and not (
-            args.enumerate_projects or args.enumerate_groups or args.project_path):
+            args.enumerate_projects or args.enumerate_groups or
+            args.project_path or args.self_enumeration):
         errors.append(
-            "--enumerate-secrets requires either --enumerate-projects and/or --enumerate-groups, or --project-path")
+            "--enumerate-secrets requires either --enumerate-projects and/or --enumerate-groups, --project-path, or --self-enumeration")
 
     # Check exfil-secrets-via-ppe dependencies
     if args.exfil_secrets_via_ppe:


### PR DESCRIPTION
By documentation, glato is supposed to enumerate everything when using `--self-enumeration` accompained by `--enumerate-secrets`:

https://github.com/praetorian-inc/glato/blob/d15090053138ab1cfdcad7db233bbb656c668734/README.md?plain=1#L187-L188

But doing so throws an error:

```
$ glato ... --self-enumeration --enumerate-secrets
Error: Invalid argument combination(s):
  - --enumerate-secrets requires either --enumerate-projects and/or --enumerate-groups, or --project-path
```

This PR fixes this by accepting run `--enumerate-secrets` with `--self-enumeration` as well.